### PR TITLE
remove edge and Firefox platform status

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -367,56 +367,6 @@
 
         <ul class="sites">
 
-            <!-- Firefox platform status -->
-            <li class="site firefox-status">
-                <article class="site__inner" itemscope itemtype="http://schema.org/WebSite">
-                    <h3 class="site__title" itemprop="name" translate="no">Firefox platform status</h3>
-                    <p class="site__description" itemprop="abstract">Implementation & standardization roadmap for web platform features.</p>
-                    <div class="site__links">
-                        <a class="site__link site__link--main | flex-center nowrap" href="https://platform-status.mozilla.org" itemprop="url" translate="no">
-                            <span class="site__link__inner">platform-status.mozilla.org</span>
-                        </a>
-                        <aside class="site__secondary-links | flex-center">
-                            <a class="site__link | flex-center" href="https://github.com/mozilla/platform-status" title="Firefox platform status code repository" itemscope itemtype="http://schema.org/SoftwareSourceCode">
-                                <meta itemprop="codeRepository" content="https://github.com/mozilla/platform-status">
-                                <svg width="33" height="33">
-                                    <title>Code</title>
-                                    <use xlink:href="#code-path"/>
-                                </svg>
-                            </a>
-                       </aside>
-                    </div>
-                </article>
-            </li>
-
-            <!-- Microsoft Edge platform status -->
-            <li class="site edge-status">
-                <article class="site__inner" itemscope itemtype="http://schema.org/WebSite">
-                    <h3 class="site__title" itemprop="name" translate="no">Edge platform status</h3>
-                    <p class="site__description" itemprop="abstract">View the status of web platform features in Edge Chromium and EdgeHTML.</p>
-                    <div class="site__links">
-                        <a class="site__link site__link--main | flex-center nowrap" href="https://status.microsoftedge.com" itemprop="url" translate="no">
-                            <span class="site__link__inner">status.microsoftedge.com</span>
-                        </a>
-                        <aside class="site__secondary-links | flex-center">
-                            <a class="site__link | flex-center" href="https://github.com/MicrosoftEdge/Status" title="Microsoft Edge platform status code repository" itemscope itemtype="http://schema.org/SoftwareSourceCode">
-                                <meta itemprop="codeRepository" content="https://github.com/MicrosoftEdge/Status">
-                                <svg width="33" height="33">
-                                    <title>Code</title>
-                                    <use xlink:href="#code-path"/>
-                                </svg>
-                            </a>
-                            <a class="site__link | flex-center" href="https://twitter.com/msedgedev" title="Microsoft Edge team on Twitter" itemprop="sameAs">
-                                <svg width="25" height="19">
-                                    <title>Twitter</title>
-                                    <use xlink:href="#twitter-path"/>
-                                </svg>
-                            </a>
-                       </aside>
-                    </div>
-                </article>
-            </li>
-
             <!-- Webkit status -->
             <li class="site webkit-status">
                 <article class="site__inner" itemscope itemtype="http://schema.org/WebSite">

--- a/src/sass/site/_colors.scss
+++ b/src/sass/site/_colors.scss
@@ -22,20 +22,6 @@
   --site-accent: hsl(0, 0%, 100%);
 }
 
-.edge-status {
-  --site-primary: hsla(0, 0%, 100%, .85);
-  --site-bg: hsl(217, 45%, 25%);
-  --site-accent: hsl(207, 100%, 65%);
-}
-
-.firefox-status {
-  --site-primary: hsla(0, 0%, 100%, .85);
-  --site-accent: hsl(0, 0%, 100%);
-
-  // https://mozilla.design/firefox/color/
-  --site-bg: linear-gradient(to right, hsl(21, 99%, 61%) 0%, hsl(349, 100%, 62%) 100%);
-}
-
 .html5accessibility {
   --site-primary: hsl(0, 0%, 20%);
   --site-bg: hsl(0, 0%, 97%);


### PR DESCRIPTION
As the commit message said, Firefox and edge platform status are removed to resolve the issue #41 