### PR TITLE
Remove links to Twitter

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -85,12 +85,6 @@
                                     <use xlink:href="#code-path"/>
                                 </svg>
                             </a>
-                            <a class="site__link | flex-center" href="https://twitter.com/caniuse" title="Can I Use on Twitter" itemprop="sameAs">
-                                <svg width="25" height="19">
-                                    <title>Twitter</title>
-                                    <use xlink:href="#twitter-path"/>
-                                </svg>
-                            </a>
                         </aside>
                     </div>
                 </article>
@@ -117,12 +111,6 @@
                                 <svg width="19" height="21">
                                     <title>Mastodon</title>
                                     <use xlink:href="#mastodon-path"/>
-                                </svg>
-                            </a>
-                            <a class="site__link | flex-center" href="https://twitter.com/canistopie11" title="Can I Stop on Twitter" itemprop="sameAs">
-                                <svg width="25" height="19">
-                                    <title>Twitter</title>
-                                    <use xlink:href="#twitter-path"/>
                                 </svg>
                             </a>
                         </aside>
@@ -157,12 +145,6 @@
                                     <use xlink:href="#code-path"/>
                                 </svg>
                             </a>
-                            <a class="site__link | flex-center" href="https://twitter.com/CoreyGinnivan" title="Who Can Use on Twitter">
-                                <svg width="25" height="19">
-                                    <title>Twitter</title>
-                                    <use xlink:href="#twitter-path"/>
-                                </svg>
-                            </a>
                         </aside>
                     </div>
                 </article>
@@ -177,14 +159,6 @@
                         <a class="site__link site__link--main | flex-center nowrap" href="https://powermapper.com/tests" itemprop="url" translate="no">
                             <span class="site__link__inner">powermapper.com/tests</span>
                         </a>
-                        <aside class="site__secondary-links | flex-center">
-                            <a class="site__link | flex-center" href="https://twitter.com/powermapper" title="Accessibility Support on Twitter" itemprop="sameAs">
-                                <svg width="25" height="19">
-                                    <title>Twitter</title>
-                                    <use xlink:href="#twitter-path"/>
-                                </svg>
-                            </a>
-                        </aside>
                     </div>
                 </article>
             </li>
@@ -206,10 +180,10 @@
                                     <use xlink:href="#code-path"/>
                                 </svg>
                             </a>
-                            <a class="site__link | flex-center" href="https://twitter.com/mfairchild365" title="Accessibility Support on Twitter">
-                                <svg width="25" height="19">
-                                    <title>Twitter</title>
-                                    <use xlink:href="#twitter-path"/>
+                            <a class="site__link | flex-center" href="https://mastodon.social/@mfairchild365" title="Accessibility Support author on Mastodon">
+                                <svg width="19" height="21">
+                                    <title>Mastodon</title>
+                                    <use xlink:href="#mastodon-path"/>
                                 </svg>
                             </a>
                         </aside>
@@ -234,10 +208,10 @@
                                     <use xlink:href="#code-path"/>
                                 </svg>
                             </a>
-                            <a class="site__link | flex-center" href="https://mobile.twitter.com/stevefaulkner" title="HTML5 Accessibility on Twitter">
-                                <svg width="25" height="19">
-                                    <title>Twitter</title>
-                                    <use xlink:href="#twitter-path"/>
+                            <a class="site__link | flex-center" href="https://mastodon.social/@stevefaulkner" title="HTML5 Accessibility author on Mastodon">
+                                <svg width="19" height="21">
+                                    <title>Mastodon</title>
+                                    <use xlink:href="#mastodon-path"/>
                                 </svg>
                             </a>
                         </aside>
@@ -270,12 +244,6 @@
                                 <svg width="33" height="33">
                                     <title>Code</title>
                                     <use xlink:href="#code-path"/>
-                                </svg>
-                            </a>
-                            <a class="site__link | flex-center" href="https://twitter.com/mozdevnet" title="MDN on Twitter" itemprop="sameAs">
-                                <svg width="25" height="19">
-                                    <title>Twitter</title>
-                                    <use xlink:href="#twitter-path"/>
                                 </svg>
                             </a>
                         </aside>
@@ -344,19 +312,13 @@
                                     <use xlink:href="#code-path"/>
                                 </svg>
                             </a>
-                            <a class="site__link | flex-center" href="https://twitter.com/privacytests" title="Privacy Tests on Twitter" itemprop="sameAs">
-                                <svg width="25" height="19">
-                                    <title>Twitter</title>
-                                    <use xlink:href="#twitter-path"/>
-                                </svg>
-                            </a>
                         </aside>
                     </div>
                 </article>
             </li>
 
 
-            <!-- Privacy Tests -->
+            <!-- Can I Devtools -->
             <li class="site canidevtools">
                 <article class="site__inner" itemscope itemtype="http://schema.org/WebSite">
                     <h3 class="site__title" itemprop="name" translate="no">Can I Devtools</h3>
@@ -371,12 +333,6 @@
                                 <svg width="33" height="33">
                                     <title>Code</title>
                                     <use xlink:href="#code-path"/>
-                                </svg>
-                            </a>
-                            <a class="site__link | flex-center" href="https://twitter.com/canidevtools" title="Can I Devtools on Twitter" itemprop="sameAs">
-                                <svg width="25" height="19">
-                                    <title>Twitter</title>
-                                    <use xlink:href="#twitter-path"/>
                                 </svg>
                             </a>
                         </aside>
@@ -401,10 +357,10 @@
                                     <use xlink:href="#code-path"/>
                                 </svg>
                             </a>
-                            <a class="site__link | flex-center" href="https://twitter.com/DasSurma" title="Is Houdini Ready Yet? on Twitter" itemprop="sameAs">
-                                <svg width="25" height="19">
-                                    <title>Twitter</title>
-                                    <use xlink:href="#twitter-path"/>
+                            <a class="site__link | flex-center" href="https://toot.cafe/@surma" title="Is Houdini Ready Yet? author on Mastodon" itemprop="sameAs">
+                                <svg width="19" height="21">
+                                    <title>Mastodon</title>
+                                    <use xlink:href="#mastodon-path"/>
                                 </svg>
                             </a>
                         </aside>
@@ -430,14 +386,6 @@
                         <a class="site__link site__link--main | flex-center nowrap" href="https://webkit.org/status" itemprop="url" translate="no">
                             <span class="site__link__inner">webkit.org/status</span>
                         </a>
-                        <aside class="site__secondary-links | flex-center">
-                            <a class="site__link | flex-center" href="https://twitter.com/webkit" title="Webkit on Twitter" itemprop="sameAs">
-                                <svg width="25" height="19">
-                                    <title>Twitter</title>
-                                    <use xlink:href="#twitter-path"/>
-                                </svg>
-                            </a>
-                       </aside>
                     </div>
                 </article>
             </li>
@@ -450,14 +398,6 @@
                         <a class="site__link site__link--main | flex-center nowrap" href="https://chromestatus.com" itemprop="url" translate="no">
                             <span class="site__link__inner">chromestatus.com</span>
                         </a>
-                        <aside class="site__secondary-links | flex-center">
-                            <a class="site__link | flex-center" href="https://twitter.com/ChromiumDev" title="Google Chrome Developer Relations team on Twitter" itemprop="sameAs">
-                                <svg width="25" height="19">
-                                    <title>Twitter</title>
-                                    <use xlink:href="#twitter-path"/>
-                                </svg>
-                            </a>
-                       </aside>
                     </div>
                 </article>
             </li>
@@ -489,10 +429,10 @@
                                     <use xlink:href="#code-path"/>
                                 </svg>
                             </a>
-                            <a class="site__link | flex-center" href="https://twitter.com/caniemail" title="Can I email on Twitter" itemprop="sameAs">
-                                <svg width="25" height="19">
-                                    <title>Twitter</title>
-                                    <use xlink:href="#twitter-path"/>
+                            <a class="site__link | flex-center" href="https://mastodon.social/@HTeuMeuLeu" title="Can I email author on Mastodon" itemprop="sameAs">
+                                <svg width="19" height="21">
+                                    <title>Mastodon</title>
+                                    <use xlink:href="#mastodon-path"/>
                                 </svg>
                             </a>
                         </aside>
@@ -532,10 +472,6 @@
 </footer>
 
 <svg style="display: none;">
-    <symbol id="twitter-path" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 23 19" fill="currentColor">
-        <path d="M20.3 3.02c.98-.6 1.73-1.52 2.08-2.63-.9.54-1.93.93-3 1.14-.88-.92-2.1-1.5-3.48-1.5-2.62 0-4.74 2.13-4.74 4.75 0 .36.04.73.12 1.07C7.34 5.67 3.84 3.8 1.5.9c-.4.7-.65 1.53-.65 2.4 0 1.65.84 3.1 2.1 3.95-.76-.02-1.5-.24-2.13-.6v.07c0 2.3 1.63 4.2 3.8 4.65-.4.1-.82.17-1.25.17-.3 0-.6-.03-.9-.1.6 1.9 2.37 3.27 4.44 3.3-1.6 1.28-3.66 2.04-5.88 2.04-.38 0-.76-.02-1.13-.07 2.1 1.36 4.58 2.15 7.26 2.15 8.73 0 13.5-7.24 13.5-13.5v-.62c.92-.67 1.73-1.5 2.36-2.46-.85.38-1.76.63-2.72.75z" fill-rule="nonzero"></path>
-    </symbol>
-
     <symbol id="mastodon-path" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 24" fill="currentColor" fill-rule="evenodd">
         <path d="M15.68 18.293c2.954-.359 5.528-2.213 5.85-3.905h.002c.509-2.667.467-6.509.467-6.509 0-5.206-3.352-6.732-3.352-6.732C16.956.357 14.054.025 11.039 0h-.075C7.95.025 5.05.357 3.358 1.147c0 0-3.352 1.526-3.352 6.732l-.003.998c-.005.959-.01 2.022.018 3.132.122 5.09.918 10.108 5.543 11.356 2.133.574 3.965.695 5.44.612 2.675-.152 4.176-.972 4.176-.972l-.088-1.974s-1.913.613-4.058.538c-2.127-.074-4.373-.234-4.717-2.89a5.587 5.587 0 01-.047-.745s2.088.518 4.733.642c1.618.076 3.136-.097 4.676-.283zm2.365-3.705V8.284c0-1.29-.323-2.313-.97-3.07-.668-.758-1.542-1.146-2.628-1.146-1.256 0-2.207.49-2.836 1.473l-.612 1.043-.61-1.043c-.63-.982-1.58-1.473-2.836-1.473-1.086 0-1.962.388-2.628 1.146-.648.757-.971 1.78-.971 3.07v6.304h2.455v-6.12c0-1.289.533-1.944 1.6-1.944 1.18 0 1.77.777 1.77 2.312v3.35h2.44v-3.35c0-1.536.592-2.312 1.772-2.312 1.066 0 1.6.655 1.6 1.945v6.119h2.454z"/>
     </symbol>


### PR DESCRIPTION
Closes #60.

Also
- Decreases the HTML payload by 8%, down from 4.87 to 4.5 KB (gzip compressed).
- Increases rage against Musk by 8%, up from 825 to 891.