### PR TITLE
Add accessibility tests

### DIFF
--- a/.github/workflows/links-cron.yml
+++ b/.github/workflows/links-cron.yml
@@ -11,7 +11,7 @@ on:
 jobs:
 
   linkChecker:
-  
+
     runs-on: ubuntu-latest
 
     steps:
@@ -23,7 +23,7 @@ jobs:
           args: 'https://canwe.dev'
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          
+
       - name: Create issue
         if: env.lychee_exit_code != 0
         uses: peter-evans/create-issue-from-file@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env
 /public
 /node_modules
+/tests/results

--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@ Before running tests locally:
 
 You can also play with Playwright GUI by running `npm run test-gui`.
 
-### Local tests results
+#### Local tests results
 
 When running the tests locally, the results are in `/tests/results`:
 - `{tld}-{timestamp}.json`: JSON report of the test suites;
 - `html/index.html`: HTML report of the latest test suites;
 - `axe-html/{tld}-{timestamp}-{wcag2-a|wcag2-aa|others}.html`: HTML reports of the accessibility tests, split by category (WCAG 2 A, WCAG 2 AA, others);
 
-### GitHub Action tests results
+#### GitHub Action tests results
 
 When running in a GitHub action, the “summary” view of the GitHub Action has an _artifact_ section at the very bottom. The artifact archive contains the same HTML report as in `html/index.html` when you run tests locally.
 

--- a/README.md
+++ b/README.md
@@ -22,14 +22,27 @@ Websites colors are CSS custom properties in [`/src/sass/site/_colors.scss`](/sr
 
 ### Tests
 
-Tests use [Playwright](https://playwright.dev) and can be run with `npm test`.
+Tests use [Playwright](https://playwright.dev) and can be run with `npm test`. They can all run locally or in a GitHub action.
 
-Before being able to run tests:
-- make sure the project is accessible from a URL;
+Before running tests locally:
+- make sure the project is accessible from a URL (e.g. using `npm run preview`);
 - add this URL in the `PW_BASE_URL` entry of your `.env`;
 - `npx playwright install` pulls the headless browsers used by the test.
 
 You can also play with Playwright GUI by running `npm run test-gui`.
+
+### Local tests results
+
+When running the tests locally, the results are in `/tests/results`:
+- `{tld}-{timestamp}.json`: JSON report of the test suites;
+- `html/index.html`: HTML report of the latest test suites;
+- `axe-html/{tld}-{timestamp}-{wcag2-a|wcag2-aa|others}.html`: HTML reports of the accessibility tests, split by category (WCAG 2 A, WCAG 2 AA, others);
+
+### GitHub Action tests results
+
+When running in a GitHub action, the “summary” view of the GitHub Action has an _artifact_ section at the very bottom. The artifact archive contains the same HTML report as in `html/index.html` when you run tests locally.
+
+When you open it and pick one of the accessibility tests, look into the “attachment” to find the HTML report dedicated to accessibility issues (as well as a JSON file).
 
 ## Various
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
                 "normalize.css": "^8.0"
             },
             "devDependencies": {
+                "@axe-core/playwright": "^4.6.1",
                 "@playwright/test": "^1.30.0",
+                "axe-html-reporter": "^2.2.3",
                 "cssnano": "^6",
                 "double-dash.scss": "^1",
                 "family.scss": "^1.0",
@@ -24,6 +26,18 @@
             },
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/@axe-core/playwright": {
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.6.1.tgz",
+            "integrity": "sha512-XMKP2OzGfGIYpU9G9FgI2ulyjEXQDP6qtZerOwdQ7YC1w4SFgofK3ogSk0qVoy0QI+q6XWLUJMfMMkUwdTR2dA==",
+            "dev": true,
+            "dependencies": {
+                "axe-core": "^4.6.3"
+            },
+            "peerDependencies": {
+                "playwright": ">= 1.0.0"
             }
         },
         "node_modules/@csstools/cascade-layer-name-parser": {
@@ -831,6 +845,31 @@
                 "postcss": "^8.1.0"
             }
         },
+        "node_modules/axe-core": {
+            "version": "4.6.3",
+            "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.6.3.tgz",
+            "integrity": "sha512-/BQzOX780JhsxDnPpH4ZiyrJAzcd8AfzFPkv+89veFSr1rcMjuq2JDCwypKaPeB6ljHp9KjXhPpjgCvQlWYuqg==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/axe-html-reporter": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/axe-html-reporter/-/axe-html-reporter-2.2.3.tgz",
+            "integrity": "sha512-io8aCEt4fJvv43W+33n3zEa8rdplH5Ti2v5fOnth3GBKLhLHarNs7jj46xGfpnGnpaNrz23/tXPHC3HbwTzwwA==",
+            "dev": true,
+            "dependencies": {
+                "mustache": "^4.0.1",
+                "rimraf": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=8.9.0"
+            },
+            "peerDependencies": {
+                "axe-core": ">=3"
+            }
+        },
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1580,6 +1619,12 @@
                 "node": ">=12"
             }
         },
+        "node_modules/fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+            "dev": true
+        },
         "node_modules/fsevents": {
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -1599,6 +1644,26 @@
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
             "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
             "dev": true
+        },
+        "node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "dev": true,
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
         },
         "node_modules/glob-parent": {
             "version": "5.1.2",
@@ -1688,6 +1753,22 @@
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.2.1.tgz",
             "integrity": "sha512-7WYV7Q5BTs0nlQm7tl92rDYYoyELLKHoDMBKhrxEoiV4mrfVdRz8hzPiYOzH7yWjzoVEamxRuAqhxL2PLRwZYQ==",
+            "dev": true
+        },
+        "node_modules/inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+            "dev": true,
+            "dependencies": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "node_modules/inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "dev": true
         },
         "node_modules/is-binary-path": {
@@ -1844,6 +1925,15 @@
                 "node": "*"
             }
         },
+        "node_modules/mustache": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+            "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+            "dev": true,
+            "bin": {
+                "mustache": "bin/mustache"
+            }
+        },
         "node_modules/nanoid": {
             "version": "3.3.4",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
@@ -1917,6 +2007,15 @@
                 "url": "https://github.com/fb55/nth-check?sponsor=1"
             }
         },
+        "node_modules/once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+            "dev": true,
+            "dependencies": {
+                "wrappy": "1"
+            }
+        },
         "node_modules/param-case": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
@@ -1935,6 +2034,15 @@
             "dependencies": {
                 "no-case": "^3.0.4",
                 "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/path-parse": {
@@ -1965,6 +2073,23 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/playwright": {
+            "version": "1.32.3",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.32.3.tgz",
+            "integrity": "sha512-h/ylpgoj6l/EjkfUDyx8cdOlfzC96itPpPe8BXacFkqpw/YsuxkpPyVbzEq4jw+bAJh5FLgh31Ljg2cR6HV3uw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "peer": true,
+            "dependencies": {
+                "playwright-core": "1.32.3"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=14"
             }
         },
         "node_modules/playwright-core": {
@@ -3079,6 +3204,21 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/rimraf": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+            "dev": true,
+            "dependencies": {
+                "glob": "^7.1.3"
+            },
+            "bin": {
+                "rimraf": "bin.js"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/rollup": {
             "version": "3.20.1",
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.20.1.tgz",
@@ -3458,6 +3598,12 @@
             "peerDependencies": {
                 "vite": ">=2.0.0"
             }
+        },
+        "node_modules/wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+            "dev": true
         }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
                 "postcss-preset-env": "^8",
                 "postcss-safe-area": "0.1",
                 "postcss-short-size": "^4.0",
-                "sass": "^1.56.0",
+                "sass": "^1",
                 "v.scss": "^1.2.1",
                 "vite": "^4",
                 "vite-plugin-html": "^3.2.0"
@@ -594,9 +594,9 @@
             }
         },
         "node_modules/@csstools/selector-specificity": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.1.1.tgz",
-            "integrity": "sha512-jwx+WCqszn53YHOfvFMJJRd/B2GqkCBt+1MJSG6o5/s8+ytHMvDZXsJgUEWLk12UnLd7HYKac4BYU5i/Ron1Cw==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.2.0.tgz",
+            "integrity": "sha512-+OJ9konv95ClSTOJCmMZqpd5+YGsB2S+x6w3E1oaM8UuR5j8nTNHYSz8c9BEPGDOCMQYIEEGlVPj/VY64iTbGw==",
             "dev": true,
             "engines": {
                 "node": "^14 || ^16 || >=18"
@@ -606,14 +606,77 @@
                 "url": "https://opencollective.com/csstools"
             },
             "peerDependencies": {
-                "postcss": "^8.4",
                 "postcss-selector-parser": "^6.0.10"
             }
         },
+        "node_modules/@esbuild/android-arm": {
+            "version": "0.17.16",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.16.tgz",
+            "integrity": "sha512-baLqRpLe4JnKrUXLJChoTN0iXZH7El/mu58GE3WIA6/H834k0XWvLRmGLG8y8arTRS9hJJibPnF0tiGhmWeZgw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/android-arm64": {
+            "version": "0.17.16",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.16.tgz",
+            "integrity": "sha512-QX48qmsEZW+gcHgTmAj+x21mwTz8MlYQBnzF6861cNdQGvj2jzzFjqH0EBabrIa/WVZ2CHolwMoqxVryqKt8+Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/android-x64": {
+            "version": "0.17.16",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.16.tgz",
+            "integrity": "sha512-G4wfHhrrz99XJgHnzFvB4UwwPxAWZaZBOFXh+JH1Duf1I4vIVfuYY9uVLpx4eiV2D/Jix8LJY+TAdZ3i40tDow==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/darwin-arm64": {
+            "version": "0.17.16",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.16.tgz",
+            "integrity": "sha512-/Ofw8UXZxuzTLsNFmz1+lmarQI6ztMZ9XktvXedTbt3SNWDn0+ODTwxExLYQ/Hod91EZB4vZPQJLoqLF0jvEzA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/@esbuild/darwin-x64": {
-            "version": "0.17.12",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.12.tgz",
-            "integrity": "sha512-5D48jM3tW27h1qjaD9UNRuN+4v0zvksqZSPZqeSWggfMlsVdAhH3pwSfQIFJwcs9QJ9BRibPS4ViZgs3d2wsCA==",
+            "version": "0.17.16",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.16.tgz",
+            "integrity": "sha512-SzBQtCV3Pdc9kyizh36Ol+dNVhkDyIrGb/JXZqFq8WL37LIyrXU0gUpADcNV311sCOhvY+f2ivMhb5Tuv8nMOQ==",
             "cpu": [
                 "x64"
             ],
@@ -626,10 +689,282 @@
                 "node": ">=12"
             }
         },
+        "node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.17.16",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.16.tgz",
+            "integrity": "sha512-ZqftdfS1UlLiH1DnS2u3It7l4Bc3AskKeu+paJSfk7RNOMrOxmeFDhLTMQqMxycP1C3oj8vgkAT6xfAuq7ZPRA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/freebsd-x64": {
+            "version": "0.17.16",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.16.tgz",
+            "integrity": "sha512-rHV6zNWW1tjgsu0dKQTX9L0ByiJHHLvQKrWtnz8r0YYJI27FU3Xu48gpK2IBj1uCSYhJ+pEk6Y0Um7U3rIvV8g==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-arm": {
+            "version": "0.17.16",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.16.tgz",
+            "integrity": "sha512-n4O8oVxbn7nl4+m+ISb0a68/lcJClIbaGAoXwqeubj/D1/oMMuaAXmJVfFlRjJLu/ZvHkxoiFJnmbfp4n8cdSw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-arm64": {
+            "version": "0.17.16",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.16.tgz",
+            "integrity": "sha512-8yoZhGkU6aHu38WpaM4HrRLTFc7/VVD9Q2SvPcmIQIipQt2I/GMTZNdEHXoypbbGao5kggLcxg0iBKjo0SQYKA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-ia32": {
+            "version": "0.17.16",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.16.tgz",
+            "integrity": "sha512-9ZBjlkdaVYxPNO8a7OmzDbOH9FMQ1a58j7Xb21UfRU29KcEEU3VTHk+Cvrft/BNv0gpWJMiiZ/f4w0TqSP0gLA==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-loong64": {
+            "version": "0.17.16",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.16.tgz",
+            "integrity": "sha512-TIZTRojVBBzdgChY3UOG7BlPhqJz08AL7jdgeeu+kiObWMFzGnQD7BgBBkWRwOtKR1i2TNlO7YK6m4zxVjjPRQ==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-mips64el": {
+            "version": "0.17.16",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.16.tgz",
+            "integrity": "sha512-UPeRuFKCCJYpBbIdczKyHLAIU31GEm0dZl1eMrdYeXDH+SJZh/i+2cAmD3A1Wip9pIc5Sc6Kc5cFUrPXtR0XHA==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-ppc64": {
+            "version": "0.17.16",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.16.tgz",
+            "integrity": "sha512-io6yShgIEgVUhExJejJ21xvO5QtrbiSeI7vYUnr7l+v/O9t6IowyhdiYnyivX2X5ysOVHAuyHW+Wyi7DNhdw6Q==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-riscv64": {
+            "version": "0.17.16",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.16.tgz",
+            "integrity": "sha512-WhlGeAHNbSdG/I2gqX2RK2gfgSNwyJuCiFHMc8s3GNEMMHUI109+VMBfhVqRb0ZGzEeRiibi8dItR3ws3Lk+cA==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-s390x": {
+            "version": "0.17.16",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.16.tgz",
+            "integrity": "sha512-gHRReYsJtViir63bXKoFaQ4pgTyah4ruiMRQ6im9YZuv+gp3UFJkNTY4sFA73YDynmXZA6hi45en4BGhNOJUsw==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-x64": {
+            "version": "0.17.16",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.16.tgz",
+            "integrity": "sha512-mfiiBkxEbUHvi+v0P+TS7UnA9TeGXR48aK4XHkTj0ZwOijxexgMF01UDFaBX7Q6CQsB0d+MFNv9IiXbIHTNd4g==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/netbsd-x64": {
+            "version": "0.17.16",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.16.tgz",
+            "integrity": "sha512-n8zK1YRDGLRZfVcswcDMDM0j2xKYLNXqei217a4GyBxHIuPMGrrVuJ+Ijfpr0Kufcm7C1k/qaIrGy6eG7wvgmA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/openbsd-x64": {
+            "version": "0.17.16",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.16.tgz",
+            "integrity": "sha512-lEEfkfsUbo0xC47eSTBqsItXDSzwzwhKUSsVaVjVji07t8+6KA5INp2rN890dHZeueXJAI8q0tEIfbwVRYf6Ew==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/sunos-x64": {
+            "version": "0.17.16",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.16.tgz",
+            "integrity": "sha512-jlRjsuvG1fgGwnE8Afs7xYDnGz0dBgTNZfgCK6TlvPH3Z13/P5pi6I57vyLE8qZYLrGVtwcm9UbUx1/mZ8Ukag==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-arm64": {
+            "version": "0.17.16",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.16.tgz",
+            "integrity": "sha512-TzoU2qwVe2boOHl/3KNBUv2PNUc38U0TNnzqOAcgPiD/EZxT2s736xfC2dYQbszAwo4MKzzwBV0iHjhfjxMimg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-ia32": {
+            "version": "0.17.16",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.16.tgz",
+            "integrity": "sha512-B8b7W+oo2yb/3xmwk9Vc99hC9bNolvqjaTZYEfMQhzdpBsjTvZBlXQ/teUE55Ww6sg//wlcDjOaqldOKyigWdA==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-x64": {
+            "version": "0.17.16",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.16.tgz",
+            "integrity": "sha512-xJ7OH/nanouJO9pf03YsL9NAFQBHd8AqfrQd7Pf5laGyyTt/gToul6QYOA/i5i/q8y9iaM5DQFNTgpi995VkOg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/@jridgewell/gen-mapping": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-            "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+            "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
             "dev": true,
             "dependencies": {
                 "@jridgewell/set-array": "^1.0.1",
@@ -659,9 +994,9 @@
             }
         },
         "node_modules/@jridgewell/source-map": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
-            "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.3.tgz",
+            "integrity": "sha512-b+fsZXeLYi9fEULmfBrhxn4IrPlINf8fiNarzTof004v3lFdntdwa9PF7vFJqm3mg7s+ScJMxXaE3Acp1irZcg==",
             "dev": true,
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.0",
@@ -669,20 +1004,26 @@
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.4.14",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-            "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+            "version": "1.4.15",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+            "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
             "dev": true
         },
         "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.17",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
-            "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+            "version": "0.3.18",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
+            "integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
             "dev": true,
             "dependencies": {
                 "@jridgewell/resolve-uri": "3.1.0",
                 "@jridgewell/sourcemap-codec": "1.4.14"
             }
+        },
+        "node_modules/@jridgewell/trace-mapping/node_modules/@jridgewell/sourcemap-codec": {
+            "version": "1.4.14",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+            "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+            "dev": true
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -761,15 +1102,15 @@
             }
         },
         "node_modules/@types/node": {
-            "version": "18.11.18",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
-            "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
+            "version": "18.15.11",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
+            "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==",
             "dev": true
         },
         "node_modules/acorn": {
-            "version": "8.8.1",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
-            "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
+            "version": "8.8.2",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+            "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
             "dev": true,
             "bin": {
                 "acorn": "bin/acorn"
@@ -970,9 +1311,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001477",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001477.tgz",
-            "integrity": "sha512-lZim4iUHhGcy5p+Ri/G7m84hJwncj+Kz7S5aD4hoQfslKZJgt0tHc/hafVbqHC5bbhHb+mrW2JOUHkI5KH7toQ==",
+            "version": "1.0.30001478",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001478.tgz",
+            "integrity": "sha512-gMhDyXGItTHipJj2ApIvR+iVB5hd0KP3svMWWXDvZOmjzJJassGLMfxRkQCSYgGd2gtdL/ReeiyvMSFD1Ss6Mw==",
             "dev": true,
             "funding": [
                 {
@@ -1033,9 +1374,9 @@
             }
         },
         "node_modules/clean-css": {
-            "version": "5.3.1",
-            "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.1.tgz",
-            "integrity": "sha512-lCr8OHhiWCTw4v8POJovCoh4T7I9U11yVsPjMWWnnMmp9ZowCxyad1Pathle/9HjaDp+fdQKjO9fQydE6RHTZg==",
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.2.tgz",
+            "integrity": "sha512-JVJbM+f3d3Q704rF4bqQ5UUyTtuJ0JRKNbTKVEeujCCBoMdkEi+V+e8oktO9qGQNSvHrFTM6JZRXrUvGR1czww==",
             "dev": true,
             "dependencies": {
                 "source-map": "~0.6.0"
@@ -1173,15 +1514,15 @@
             }
         },
         "node_modules/css-select": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
-            "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+            "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
             "dev": true,
             "dependencies": {
                 "boolbase": "^1.0.0",
-                "css-what": "^6.0.1",
-                "domhandler": "^4.3.1",
-                "domutils": "^2.8.0",
+                "css-what": "^6.1.0",
+                "domhandler": "^5.0.2",
+                "domutils": "^3.0.1",
                 "nth-check": "^2.0.1"
             },
             "funding": {
@@ -1344,14 +1685,14 @@
             "dev": true
         },
         "node_modules/dom-serializer": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
-            "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+            "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
             "dev": true,
             "dependencies": {
-                "domelementtype": "^2.0.1",
-                "domhandler": "^4.2.0",
-                "entities": "^2.0.0"
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.2",
+                "entities": "^4.2.0"
             },
             "funding": {
                 "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
@@ -1370,12 +1711,12 @@
             ]
         },
         "node_modules/domhandler": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-            "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+            "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
             "dev": true,
             "dependencies": {
-                "domelementtype": "^2.2.0"
+                "domelementtype": "^2.3.0"
             },
             "engines": {
                 "node": ">= 4"
@@ -1385,14 +1726,14 @@
             }
         },
         "node_modules/domutils": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-            "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+            "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
             "dev": true,
             "dependencies": {
-                "dom-serializer": "^1.0.1",
-                "domelementtype": "^2.2.0",
-                "domhandler": "^4.2.0"
+                "dom-serializer": "^2.0.0",
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.1"
             },
             "funding": {
                 "url": "https://github.com/fb55/domutils?sponsor=1"
@@ -1438,9 +1779,9 @@
             "integrity": "sha512-Pqdl2z2xL5Q/PBXbuT2mEEPA5novFqM0A3SVp9yMsgfMTREPybFBzunpBg5pW3STBSH/rqBsUXjOFN4YJzDC8A=="
         },
         "node_modules/ejs": {
-            "version": "3.1.8",
-            "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.8.tgz",
-            "integrity": "sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==",
+            "version": "3.1.9",
+            "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.9.tgz",
+            "integrity": "sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==",
             "dev": true,
             "dependencies": {
                 "jake": "^10.8.5"
@@ -1453,24 +1794,27 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.284",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
-            "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
+            "version": "1.4.361",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.361.tgz",
+            "integrity": "sha512-VocVwjPp05HUXzf3xmL0boRn5b0iyqC7amtDww84Jb1QJNPBc7F69gJyEeXRoriLBC4a5pSyckdllrXAg4mmRA==",
             "dev": true
         },
         "node_modules/entities": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-            "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
+            "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
             "dev": true,
+            "engines": {
+                "node": ">=0.12"
+            },
             "funding": {
                 "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
         "node_modules/esbuild": {
-            "version": "0.17.12",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.12.tgz",
-            "integrity": "sha512-bX/zHl7Gn2CpQwcMtRogTTBf9l1nl+H6R8nUbjk+RuKqAE3+8FDulLA+pHvX7aA7Xe07Iwa+CWvy9I8Y2qqPKQ==",
+            "version": "0.17.16",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.16.tgz",
+            "integrity": "sha512-aeSuUKr9aFVY9Dc8ETVELGgkj4urg5isYx8pLf4wlGgB0vTFjxJQdHnNH6Shmx4vYYrOTLCHtRI5i1XZ9l2Zcg==",
             "dev": true,
             "hasInstallScript": true,
             "bin": {
@@ -1480,28 +1824,28 @@
                 "node": ">=12"
             },
             "optionalDependencies": {
-                "@esbuild/android-arm": "0.17.12",
-                "@esbuild/android-arm64": "0.17.12",
-                "@esbuild/android-x64": "0.17.12",
-                "@esbuild/darwin-arm64": "0.17.12",
-                "@esbuild/darwin-x64": "0.17.12",
-                "@esbuild/freebsd-arm64": "0.17.12",
-                "@esbuild/freebsd-x64": "0.17.12",
-                "@esbuild/linux-arm": "0.17.12",
-                "@esbuild/linux-arm64": "0.17.12",
-                "@esbuild/linux-ia32": "0.17.12",
-                "@esbuild/linux-loong64": "0.17.12",
-                "@esbuild/linux-mips64el": "0.17.12",
-                "@esbuild/linux-ppc64": "0.17.12",
-                "@esbuild/linux-riscv64": "0.17.12",
-                "@esbuild/linux-s390x": "0.17.12",
-                "@esbuild/linux-x64": "0.17.12",
-                "@esbuild/netbsd-x64": "0.17.12",
-                "@esbuild/openbsd-x64": "0.17.12",
-                "@esbuild/sunos-x64": "0.17.12",
-                "@esbuild/win32-arm64": "0.17.12",
-                "@esbuild/win32-ia32": "0.17.12",
-                "@esbuild/win32-x64": "0.17.12"
+                "@esbuild/android-arm": "0.17.16",
+                "@esbuild/android-arm64": "0.17.16",
+                "@esbuild/android-x64": "0.17.16",
+                "@esbuild/darwin-arm64": "0.17.16",
+                "@esbuild/darwin-x64": "0.17.16",
+                "@esbuild/freebsd-arm64": "0.17.16",
+                "@esbuild/freebsd-x64": "0.17.16",
+                "@esbuild/linux-arm": "0.17.16",
+                "@esbuild/linux-arm64": "0.17.16",
+                "@esbuild/linux-ia32": "0.17.16",
+                "@esbuild/linux-loong64": "0.17.16",
+                "@esbuild/linux-mips64el": "0.17.16",
+                "@esbuild/linux-ppc64": "0.17.16",
+                "@esbuild/linux-riscv64": "0.17.16",
+                "@esbuild/linux-s390x": "0.17.16",
+                "@esbuild/linux-x64": "0.17.16",
+                "@esbuild/netbsd-x64": "0.17.16",
+                "@esbuild/openbsd-x64": "0.17.16",
+                "@esbuild/sunos-x64": "0.17.16",
+                "@esbuild/win32-arm64": "0.17.16",
+                "@esbuild/win32-ia32": "0.17.16",
+                "@esbuild/win32-x64": "0.17.16"
             }
         },
         "node_modules/escalade": {
@@ -1542,9 +1886,9 @@
             }
         },
         "node_modules/fastq": {
-            "version": "1.14.0",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.14.0.tgz",
-            "integrity": "sha512-eR2D+V9/ExcbF9ls441yIuN6TI2ED1Y2ZcA5BmMtJsOkWOFRJQ0Jt0g1UwqXJJVAb+V+umH5Dfr8oh4EVP7VVg==",
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+            "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
             "dev": true,
             "dependencies": {
                 "reusify": "^1.0.4"
@@ -1569,9 +1913,9 @@
             }
         },
         "node_modules/filelist/node_modules/minimatch": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
-            "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
             "dev": true,
             "dependencies": {
                 "brace-expansion": "^2.0.1"
@@ -1678,9 +2022,9 @@
             }
         },
         "node_modules/graceful-fs": {
-            "version": "4.2.10",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+            "version": "4.2.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
             "dev": true
         },
         "node_modules/has": {
@@ -1750,9 +2094,9 @@
             }
         },
         "node_modules/immutable": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.2.1.tgz",
-            "integrity": "sha512-7WYV7Q5BTs0nlQm7tl92rDYYoyELLKHoDMBKhrxEoiV4mrfVdRz8hzPiYOzH7yWjzoVEamxRuAqhxL2PLRwZYQ==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.0.tgz",
+            "integrity": "sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg==",
             "dev": true
         },
         "node_modules/inflight": {
@@ -1784,9 +2128,9 @@
             }
         },
         "node_modules/is-core-module": {
-            "version": "2.11.0",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
-            "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.0.tgz",
+            "integrity": "sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==",
             "dev": true,
             "dependencies": {
                 "has": "^1.0.3"
@@ -1935,10 +2279,16 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-            "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+            "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
             },
@@ -1966,10 +2316,78 @@
                 "he": "1.2.0"
             }
         },
+        "node_modules/node-html-parser/node_modules/css-select": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
+            "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
+            "dev": true,
+            "dependencies": {
+                "boolbase": "^1.0.0",
+                "css-what": "^6.0.1",
+                "domhandler": "^4.3.1",
+                "domutils": "^2.8.0",
+                "nth-check": "^2.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/fb55"
+            }
+        },
+        "node_modules/node-html-parser/node_modules/dom-serializer": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
+            "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+            "dev": true,
+            "dependencies": {
+                "domelementtype": "^2.0.1",
+                "domhandler": "^4.2.0",
+                "entities": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+            }
+        },
+        "node_modules/node-html-parser/node_modules/domhandler": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+            "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+            "dev": true,
+            "dependencies": {
+                "domelementtype": "^2.2.0"
+            },
+            "engines": {
+                "node": ">= 4"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domhandler?sponsor=1"
+            }
+        },
+        "node_modules/node-html-parser/node_modules/domutils": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+            "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+            "dev": true,
+            "dependencies": {
+                "dom-serializer": "^1.0.1",
+                "domelementtype": "^2.2.0",
+                "domhandler": "^4.2.0"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domutils?sponsor=1"
+            }
+        },
+        "node_modules/node-html-parser/node_modules/entities": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+            "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+            "dev": true,
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
         "node_modules/node-releases": {
-            "version": "2.0.8",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.8.tgz",
-            "integrity": "sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A==",
+            "version": "2.0.10",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.10.tgz",
+            "integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==",
             "dev": true
         },
         "node_modules/normalize-path": {
@@ -3178,12 +3596,12 @@
             }
         },
         "node_modules/resolve": {
-            "version": "1.22.1",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-            "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
+            "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
             "dev": true,
             "dependencies": {
-                "is-core-module": "^2.9.0",
+                "is-core-module": "^2.11.0",
                 "path-parse": "^1.0.7",
                 "supports-preserve-symlinks-flag": "^1.0.0"
             },
@@ -3220,9 +3638,9 @@
             }
         },
         "node_modules/rollup": {
-            "version": "3.20.1",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.20.1.tgz",
-            "integrity": "sha512-sz2w8cBJlWQ2E17RcpvHuf4sk2BQx4tfKDnjNPikEpLEevrbIAR7CH3PGa2hpPwWbNgPaA9yh9Jzljds5bc9zg==",
+            "version": "3.20.2",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.20.2.tgz",
+            "integrity": "sha512-3zwkBQl7Ai7MFYQE0y1MeQ15+9jsi7XxfrqwTb/9EK8D9C9+//EBR4M+CuA1KODRaNbFez/lWxA5vhEGZp4MUg==",
             "dev": true,
             "bin": {
                 "rollup": "dist/bin/rollup"
@@ -3259,9 +3677,9 @@
             }
         },
         "node_modules/sass": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.61.0.tgz",
-            "integrity": "sha512-PDsN7BrVkNZK2+dj/dpKQAWZavbAQ87IXqVvw2+oEYI+GwlTWkvbQtL7F2cCNbMqJEYKPh1EcjSxsnqIb/kyaQ==",
+            "version": "1.62.0",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.62.0.tgz",
+            "integrity": "sha512-Q4USplo4pLYgCi+XlipZCWUQz5pkg/ruSSgJ0WRDSb/+3z9tXUOkQ7QPYn4XrhZKYAK4HlpaQecRwKLJX6+DBg==",
             "dev": true,
             "dependencies": {
                 "chokidar": ">=3.0.0 <4.0.0",
@@ -3367,81 +3785,10 @@
                 "url": "https://opencollective.com/svgo"
             }
         },
-        "node_modules/svgo/node_modules/css-select": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
-            "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
-            "dev": true,
-            "dependencies": {
-                "boolbase": "^1.0.0",
-                "css-what": "^6.1.0",
-                "domhandler": "^5.0.2",
-                "domutils": "^3.0.1",
-                "nth-check": "^2.0.1"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/fb55"
-            }
-        },
-        "node_modules/svgo/node_modules/dom-serializer": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-            "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-            "dev": true,
-            "dependencies": {
-                "domelementtype": "^2.3.0",
-                "domhandler": "^5.0.2",
-                "entities": "^4.2.0"
-            },
-            "funding": {
-                "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-            }
-        },
-        "node_modules/svgo/node_modules/domhandler": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-            "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-            "dev": true,
-            "dependencies": {
-                "domelementtype": "^2.3.0"
-            },
-            "engines": {
-                "node": ">= 4"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/domhandler?sponsor=1"
-            }
-        },
-        "node_modules/svgo/node_modules/domutils": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-            "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
-            "dev": true,
-            "dependencies": {
-                "dom-serializer": "^2.0.0",
-                "domelementtype": "^2.3.0",
-                "domhandler": "^5.0.1"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/domutils?sponsor=1"
-            }
-        },
-        "node_modules/svgo/node_modules/entities": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-            "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.12"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/entities?sponsor=1"
-            }
-        },
         "node_modules/terser": {
-            "version": "5.16.1",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.1.tgz",
-            "integrity": "sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==",
+            "version": "5.16.9",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.9.tgz",
+            "integrity": "sha512-HPa/FdTB9XGI2H1/keLFZHxl6WNvAI4YalHGtDQTlMnJcoqSab1UwL4l1hGEhs6/GmLHBZIg/YgB++jcbzoOEg==",
             "dev": true,
             "dependencies": {
                 "@jridgewell/source-map": "^0.3.2",
@@ -3475,9 +3822,9 @@
             }
         },
         "node_modules/tslib": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+            "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
             "dev": true
         },
         "node_modules/universalify": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "postcss-preset-env": "^8",
         "postcss-safe-area": "0.1",
         "postcss-short-size": "^4.0",
-        "sass": "^1.56.0",
+        "sass": "^1",
         "v.scss": "^1.2.1",
         "vite": "^4",
         "vite-plugin-html": "^3.2.0"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
         "normalize.css": "^8.0"
     },
     "devDependencies": {
+        "@axe-core/playwright": "^4.6.1",
         "@playwright/test": "^1.30.0",
+        "axe-html-reporter": "^2.2.3",
         "cssnano": "^6",
         "double-dash.scss": "^1",
         "family.scss": "^1.0",

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -1,5 +1,6 @@
 import dotenv from 'dotenv';
 import { devices } from '@playwright/test'
+import { dateToKebab } from './tests/utils/date.mjs';
 import { isInvalidUrl } from './tests/utils/url.mjs';
 
 /**
@@ -15,8 +16,16 @@ if (isInvalidUrl(baseURL)) {
   throw new Error(`PW_BASE_URL is not a valid URL: ${baseURL}`)
 }
 
+const filename = `${process.env.SERVER_HOST}-${dateToKebab(new Date())}`
+
 /** @type {import('@playwright/test').PlaywrightTestConfig} */
 export default {
+  // testIgnore: '**accessibility-axe**',
+
+  metadata: {
+    filename,
+  },
+
   forbidOnly: !!process.env.CI,
   workers: process.env.CI ? 2 : 1,
 
@@ -51,5 +60,19 @@ export default {
     //   use: { ...devices['Desktop Safari'] },
     // },
   ],
-  reporter: process.env.CI ? [['github'], ['html']] : 'list',
+  reporter: process.env.CI
+    ? [['github'], ['html']]
+    : [
+      // ['dot'],
+      // ['list'],
+      ['html', {
+        open: 'never',
+        outputFile: `${filename}.html`, // ignored…, index.html must have its subfolder, otherwise it erases other existing files
+        outputFolder: `tests/results/html`,
+      }],
+      ['json', {
+        outputFile: `tests/results/${filename}.json`,
+      }],
+    ]
+  ,
 }

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -28,7 +28,7 @@ export default {
   },
 
   forbidOnly: !!process.env.CI,
-  workers: process.env.CI ? 2 : 1,
+  workers: process.env.CI ? 2 : undefined,
 
   ...(process.env.CI
     ? { webServer: {

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -1,7 +1,7 @@
-import dotenv from 'dotenv';
+import dotenv from 'dotenv'
 import { devices } from '@playwright/test'
-import { dateToKebab } from './tests/utils/date.mjs';
-import { isInvalidUrl } from './tests/utils/url.mjs';
+import { dateToKebab } from './tests/utils/date.mjs'
+import { isInvalidUrl } from './tests/utils/url.mjs'
 
 /**
  * Inject `.env` file entries into `process.env` if `.env` file exists.
@@ -22,6 +22,7 @@ const filename = `${process.env.SERVER_HOST}-${dateToKebab(new Date())}`
 export default {
   // testIgnore: '**accessibility-axe**',
 
+  // Metadata can be used by test suites.
   metadata: {
     filename,
   },
@@ -46,6 +47,8 @@ export default {
     trace: 'on-first-retry',
   },
   // preserveOutput: 'never',
+
+  // In CI environment, only run Chromium
   projects: [
     {
       name: 'chromium',
@@ -59,7 +62,8 @@ export default {
     //   name: 'webkit',
     //   use: { ...devices['Desktop Safari'] },
     // },
-  ],
+  ].filter(({ name }) => name == 'chromium' || !process.env.CI),
+
   reporter: process.env.CI
     ? [['github'], ['html']]
     : [

--- a/tests/accessibility-axe.spec.mjs
+++ b/tests/accessibility-axe.spec.mjs
@@ -82,6 +82,5 @@ test('It has no automatically detectable accessibility issues', async ({
   //   'nodes',
   // ])
 
-  // expect(violations.length).toBe(0)
-  expect(results.violations.length).toBe(0);
+  expect(violationsCount).toBe(0);
 });

--- a/tests/accessibility-axe.spec.mjs
+++ b/tests/accessibility-axe.spec.mjs
@@ -1,0 +1,89 @@
+import { test, expect } from '@playwright/test'
+
+// https://playwright.dev/docs/accessibility-testing
+// https://github.com/dequelabs/axe-core-npm/blob/develop/packages/playwright
+import AxeCorePlaywright from '@axe-core/playwright'
+
+import { createHtmlReport } from 'axe-html-reporter'
+import fs from 'fs'
+import { dateToKebab } from './utils/date.mjs';
+
+// Work around https://github.com/dequelabs/axe-core-npm/issues/601
+/** @type {import('@axe-core/playwright').default} */
+const AxeBuilder = AxeCorePlaywright.default;
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/');
+  // await injectAxe(page)
+});
+
+test('It has no automatically detectable accessibility issues', async ({
+  page,
+}, testInfo) => {
+  const timestamp = `canwe.test-${dateToKebab(new Date())}`
+
+  const results = await new AxeBuilder({ page }).analyze();
+
+  const violationsCount = results.violations.flatMap(v => v.nodes).length
+
+  await testInfo.attach(`axe-json-${timestamp}`, {
+    body: JSON.stringify(results, null, 2),
+    contentType: 'application/json',
+  });
+
+  /**
+   * Send Axe results to the JSON report.
+   *
+   * https://playwright.dev/docs/test-annotations#custom-annotations
+   */
+  // testInfo.annotations.push(results);
+  testInfo.annotations.push({
+    type: 'axe-violations-count',
+    description: `Accessibility violations: ${violationsCount}.`,
+    results,
+  });
+
+  /**
+   * HTML REPORT
+   */
+
+  // 1. Generate HTML string from results
+
+  const htmlReport = createHtmlReport({
+    results,
+    options: {
+      doNotCreateReportFile: true,
+    }
+  })
+    // fix syntax highlighting for `file://` protocol
+    .replaceAll('//cdnjs', 'https://cdnjs')
+
+  // // 2. Save HTML string in file
+
+  // const htmlReportDir = 'tests/results/axe-html'
+  // if (!fs.existsSync(htmlReportDir)) {
+  //   fs.mkdirSync(htmlReportDir, { recursive: true })
+  // }
+  // fs.writeFileSync(`${htmlReportDir}/${timestamp}.html`, htmlReport)
+
+  // 3. Attach HTML report to main Playwright report
+
+  await testInfo.attach(`axe-html-${timestamp}`, {
+    body: htmlReport,
+    contentType: 'text/html',
+  })
+
+  // console.table(results.violations, [
+  //   'index',
+  //   'id',
+  //   'impact',
+  //   'tags',
+  //   'description',
+  //   'help',
+  //   'helpUrl',
+  //   'nodes',
+  // ])
+
+  // expect(violations.length).toBe(0)
+  expect(results.violations.length).toBe(0);
+});

--- a/tests/accessibility-axe.spec.mjs
+++ b/tests/accessibility-axe.spec.mjs
@@ -6,7 +6,6 @@ import AxeCorePlaywright from '@axe-core/playwright'
 
 import { createHtmlReport } from 'axe-html-reporter'
 import fs from 'fs'
-import { dateToKebab } from './utils/date.mjs';
 
 // Work around https://github.com/dequelabs/axe-core-npm/issues/601
 /** @type {import('@axe-core/playwright').default} */
@@ -14,19 +13,18 @@ const AxeBuilder = AxeCorePlaywright.default;
 
 test.beforeEach(async ({ page }) => {
   await page.goto('/');
-  // await injectAxe(page)
 });
 
 test('It has no automatically detectable accessibility issues', async ({
   page,
 }, testInfo) => {
-  const timestamp = `canwe.test-${dateToKebab(new Date())}`
+  const { filename } = testInfo.config.metadata
 
   const results = await new AxeBuilder({ page }).analyze();
 
   const violationsCount = results.violations.flatMap(v => v.nodes).length
 
-  await testInfo.attach(`axe-json-${timestamp}`, {
+  await testInfo.attach(`axe-json-${filename}`, {
     body: JSON.stringify(results, null, 2),
     contentType: 'application/json',
   });
@@ -64,11 +62,11 @@ test('It has no automatically detectable accessibility issues', async ({
   if (!fs.existsSync(htmlReportDir)) {
     fs.mkdirSync(htmlReportDir, { recursive: true })
   }
-  fs.writeFileSync(`${htmlReportDir}/${timestamp}.html`, htmlReport)
+  fs.writeFileSync(`${htmlReportDir}/${filename}.html`, htmlReport)
 
   // 3. Attach HTML report to main Playwright report
 
-  await testInfo.attach(`axe-html-${timestamp}`, {
+  await testInfo.attach(`axe-html-${filename}`, {
     body: htmlReport,
     contentType: 'text/html',
   })

--- a/tests/accessibility-axe.spec.mjs
+++ b/tests/accessibility-axe.spec.mjs
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 import { axeCategories, createHtmlReport, testAccessibilty } from './utils/axe-core.mjs'
 
 test.beforeEach(async ({ page }) => {
-  await page.goto('/');
+  await page.goto('/')
 });
 
 axeCategories.forEach(({ name, tags, id }) =>
@@ -37,6 +37,6 @@ axeCategories.forEach(({ name, tags, id }) =>
       results,
     });
 
-    expect(violationsCount).toBe(0);
+    expect(violationsCount).toBe(0)
   })
 )

--- a/tests/accessibility-axe.spec.mjs
+++ b/tests/accessibility-axe.spec.mjs
@@ -58,13 +58,13 @@ test('It has no automatically detectable accessibility issues', async ({
     // fix syntax highlighting for `file://` protocol
     .replaceAll('//cdnjs', 'https://cdnjs')
 
-  // // 2. Save HTML string in file
+  // 2. Save HTML string in file
 
-  // const htmlReportDir = 'tests/results/axe-html'
-  // if (!fs.existsSync(htmlReportDir)) {
-  //   fs.mkdirSync(htmlReportDir, { recursive: true })
-  // }
-  // fs.writeFileSync(`${htmlReportDir}/${timestamp}.html`, htmlReport)
+  const htmlReportDir = 'tests/results/axe-html'
+  if (!fs.existsSync(htmlReportDir)) {
+    fs.mkdirSync(htmlReportDir, { recursive: true })
+  }
+  fs.writeFileSync(`${htmlReportDir}/${timestamp}.html`, htmlReport)
 
   // 3. Attach HTML report to main Playwright report
 

--- a/tests/utils/axe-core.mjs
+++ b/tests/utils/axe-core.mjs
@@ -1,0 +1,79 @@
+// https://playwright.dev/docs/accessibility-testing
+// https://github.com/dequelabs/axe-core-npm/blob/develop/packages/playwright
+import AxeCorePlaywright from '@axe-core/playwright'
+import { createHtmlReport as createAxeHtmlReport } from 'axe-html-reporter'
+import fs from 'fs'
+
+// Types workaround https://github.com/dequelabs/axe-core-npm/issues/601
+/** @type {import('@axe-core/playwright').default} */
+const AxeBuilder = AxeCorePlaywright.default;
+
+export const axeCategories = [
+  {
+    id: 'axe-wcag2-a',
+    name: 'WCAG 2.0 Level A',
+    tags: ['wcag2a', 'wcag21a'],
+  },
+  {
+    id: 'axe-wcag2-aa',
+    name: 'WCAG 2.0 Level AA',
+    tags: ['wcag2aa', 'wcag21aa', 'wcag22aa'],
+  },
+  {
+    id: 'axe-others',
+    name: 'Best Practices and experimental rules',
+    tags: ['best-practice', 'experimental'],
+  },
+]
+
+/**
+ * Test the accessibility of a page using Axe.
+ *
+ * https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md
+ * https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#axe-core-tags
+ * https://www.deque.com/axe/core-documentation/api-documentation/#api-notes
+ *
+ * @param {import('@playwright/test').Page} page Playwright page
+ * @param {string|string[]} tags Axe tags
+ * @returns {Promise<import('axe-core').AxeResults>}
+ */
+export const testAccessibilty = (page, tags = null) => {
+  const axeBuilder = new AxeBuilder({ page })
+
+  if (tags) {
+    axeBuilder.withTags(tags)
+  }
+
+  return axeBuilder.analyze()
+}
+
+/**
+ * Create HTML report from Axe results and save it to filesystem.
+ *
+ * @param {import('axe-core').AxeResults} results Axe results
+ * @param {string} filename
+ * @returns {string}
+ */
+export const createHtmlReport = (results, filename) => {
+
+  // Generate HTML report from results.
+
+  const htmlReport = createAxeHtmlReport({
+    results,
+    options: {
+      doNotCreateReportFile: true,
+    }
+  })
+    // fix syntax highlighting for `file://` protocol
+    .replaceAll('//cdnjs', 'https://cdnjs')
+
+  // Save HTML report in filesystem.
+
+  const htmlReportDir = 'tests/results/axe-html'
+  if (!fs.existsSync(htmlReportDir)) {
+    fs.mkdirSync(htmlReportDir, { recursive: true })
+  }
+  fs.writeFileSync(`${htmlReportDir}/${filename}.html`, htmlReport)
+
+  return htmlReport
+}

--- a/tests/utils/axe-core.mjs
+++ b/tests/utils/axe-core.mjs
@@ -6,7 +6,7 @@ import fs from 'fs'
 
 // Types workaround https://github.com/dequelabs/axe-core-npm/issues/601
 /** @type {import('@axe-core/playwright').default} */
-const AxeBuilder = AxeCorePlaywright.default;
+const AxeBuilder = AxeCorePlaywright.default
 
 export const axeCategories = [
   {

--- a/tests/utils/date.mjs
+++ b/tests/utils/date.mjs
@@ -1,0 +1,12 @@
+/**
+ * Convert `2023-03-02T16:59:31` into `2023-03-02-16-59-31`.
+ *
+ * @param {Date} date
+ *
+ * @returns {string}
+ */
+export const dateToKebab = date => date
+  .toISOString()
+  .substr(0, 19)
+  .replace('T', '-')
+  .replaceAll(':', '-')

--- a/tests/utils/url.mjs
+++ b/tests/utils/url.mjs
@@ -6,6 +6,11 @@
  * @returns {boolean}
  */
 export const isInvalidUrl = url => {
-  try { new URL(url); return false }
-  catch (error) { return true }
+  try {
+    new URL(url)
+    return false
+  }
+  catch (error) {
+    return true
+  }
 }


### PR DESCRIPTION
The automated accessibility tests can run locally or in a GitHub action.

When running in a GitHub action, their results are available as “artifact” (the file attachment in the summary of a GitHub action): the archive contains a HTML file with all the test suites. By opening the accessibility one in a browser and looking into the “attachment”, you get the HTML report dedicated to accessibility issues (as well as a JSON file).

- [x] Things are running.
- [x] WCAG AA violations are in their own test suites instead of being grouped will all other axe-core tags.
- [x] The explainer paragraph is documented at README.md level (or anywhere appropriate in addition to this PR). 