### PR TITLE
Fix Axe core types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
                 "normalize.css": "^8.0"
             },
             "devDependencies": {
-                "@axe-core/playwright": "^4.6.1",
+                "@axe-core/playwright": "^4.7",
                 "@playwright/test": "^1.30.0",
                 "axe-html-reporter": "^2.2.3",
                 "cssnano": "^6",
@@ -34,12 +34,12 @@
             }
         },
         "node_modules/@axe-core/playwright": {
-            "version": "4.6.1",
-            "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.6.1.tgz",
-            "integrity": "sha512-XMKP2OzGfGIYpU9G9FgI2ulyjEXQDP6qtZerOwdQ7YC1w4SFgofK3ogSk0qVoy0QI+q6XWLUJMfMMkUwdTR2dA==",
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.7.0.tgz",
+            "integrity": "sha512-zcE5DXD8fA1joWSCdug/X7rtrugCWkPTG20XDw3Bgr0n7AZYNzwdtBdlnHvbxErAz0H1SQDInTJkIu++n3b6YQ==",
             "dev": true,
             "dependencies": {
-                "axe-core": "^4.6.3"
+                "axe-core": "^4.7.0"
             },
             "peerDependencies": {
                 "playwright": ">= 1.0.0"
@@ -1457,9 +1457,9 @@
             }
         },
         "node_modules/axe-core": {
-            "version": "4.6.3",
-            "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.6.3.tgz",
-            "integrity": "sha512-/BQzOX780JhsxDnPpH4ZiyrJAzcd8AfzFPkv+89veFSr1rcMjuq2JDCwypKaPeB6ljHp9KjXhPpjgCvQlWYuqg==",
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.7.0.tgz",
+            "integrity": "sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ==",
             "dev": true,
             "engines": {
                 "node": ">=4"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "normalize.css": "^8.0"
     },
     "devDependencies": {
-        "@axe-core/playwright": "^4.6.1",
+        "@axe-core/playwright": "^4.7",
         "@playwright/test": "^1.30.0",
         "axe-html-reporter": "^2.2.3",
         "cssnano": "^6",

--- a/tests/utils/axe-core.mjs
+++ b/tests/utils/axe-core.mjs
@@ -1,12 +1,8 @@
 // https://playwright.dev/docs/accessibility-testing
 // https://github.com/dequelabs/axe-core-npm/blob/develop/packages/playwright
-import AxeCorePlaywright from '@axe-core/playwright'
+import AxeBuilder from '@axe-core/playwright'
 import { createHtmlReport as createAxeHtmlReport } from 'axe-html-reporter'
 import fs from 'fs'
-
-// Types workaround https://github.com/dequelabs/axe-core-npm/issues/601
-/** @type {import('@axe-core/playwright').default} */
-const AxeBuilder = AxeCorePlaywright.default
 
 let exclusions = []
 


### PR DESCRIPTION
[`@axe-core/playwright` `v4.7.0`](https://github.com/dequelabs/axe-core-npm/blob/e4ada1bf9985e9a7dfd2e0b4552bae1e1f5f3bbe/CHANGELOG.md) fixes types import requiring a workaround.